### PR TITLE
fix: crash when trying to run Aurora under RGLoader

### DIFF
--- a/RGLoader/Hooks.cpp
+++ b/RGLoader/Hooks.cpp
@@ -110,6 +110,9 @@ HRESULT XexStartExecutableHook(FARPROC TitleProcessInitThreadProc) {
 	PLDR_DATA_TABLE_ENTRY pDTE = (PLDR_DATA_TABLE_ENTRY)*XexExecutableModuleHandle;
 	XEX_EXECUTION_ID* pExeId = (XEX_EXECUTION_ID*)RtlImageXexHeaderField(pDTE->XexHeaderBase, XEX_HEADER_EXECUTION_ID);
 
+	if (!pExeId)
+		return res;
+
 	CHAR szTitlePluginPath0[MAX_PATH] = { 0 };
 	CHAR szTitlePluginPattern[MAX_PATH] = { 0 };
 	CHAR szTitlePluginPath1[MAX_PATH] = { 0 };


### PR DESCRIPTION
When attempting to run Aurora under RGLoader, an access violation is encountered in XexStartExecutableHook due to the Aurora image not having an execution ID header. This change adds an additional sanity check to ensure executable images have a execution ID header before proceeding with attempting to locate title plugins.